### PR TITLE
Bugfix: Do not change `FileType`

### DIFF
--- a/Fieldtrip and Brainstorm wrappers/process_gedai.m
+++ b/Fieldtrip and Brainstorm wrappers/process_gedai.m
@@ -400,9 +400,6 @@ function sInput = Run(sProcess, sInput) %#ok<DEFNU>
     sInput.A = sOutput.A;  % Use the full channel data with cleaned EEG
     
     % Update Comment logic
-    % Force DataType to 'recordings' (imported data) to ensure it stays in the same study
-    sInput.DataType = 'recordings';
-    
     new_duration = sInput.TimeVector(end) - sInput.TimeVector(1);
     
     % Get the base comment


### PR DESCRIPTION
Since `process_gedai.m` is a process of the `Filter` type, they input and the output must be the same `FileType`. More information in this [link](https://neuroimage.usc.edu/brainstorm/Tutorials/TutUserProcess#Category:_.27Filter.27_and_.27Filter2.27)

This error cause the bug of saving a `raw` data file (which is a pointer to the binary raw file) in a `imported` data file. 

Error reported in the Brainstorm Forum:
https://neuroimage.usc.edu/forums/t/error-using-gedai-plugin/54952/3

FYI @tmedani


